### PR TITLE
fix(ci): fix Docker startup_failure and React hooks lint errors

### DIFF
--- a/.github/workflows/docker-validation.yml
+++ b/.github/workflows/docker-validation.yml
@@ -22,6 +22,10 @@ jobs:
   docker-validation:
     name: Docker Validation
     if: github.event_name == 'push' || github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      security-events: write
+      actions: write
     uses: Philippe-arnd/reusable-workflow-vibecoded/.github/workflows/reusable-docker-validation.yml@main
     with:
       postgres-db: 'kanban_test'

--- a/client/src/hooks/useTasks.js
+++ b/client/src/hooks/useTasks.js
@@ -8,14 +8,6 @@ export function useTasks(session) {
   const [tasks, setTasks] = useState([])
   const [loading, setLoading] = useState(false)
 
-  useEffect(() => {
-    if (session?.user) {
-      fetchTasks()
-    } else {
-      setTasks([])
-    }
-  }, [session])
-
   async function fetchTasks() {
     try {
       setLoading(true)
@@ -41,6 +33,12 @@ export function useTasks(session) {
       setLoading(false)
     }
   }
+
+  useEffect(() => {
+    if (session?.user) {
+      fetchTasks()
+    }
+  }, [session])
 
   const addTask = async (title, mode) => {
     if (!title.trim() || !session?.user) return
@@ -279,7 +277,7 @@ export function useTasks(session) {
   }
 
   return {
-    tasks,
+    tasks: session?.user ? tasks : [],
     setTasks,
     loading,
     addTask,


### PR DESCRIPTION
## Summary

- **Docker Validation startup_failure (depuis le 30 mars)** : le job caller `docker-validation.yml` ne déclarait pas de `permissions:`, donc le token `push` vers main n'avait pas `security-events:write` (requis par Trivy SARIF) ni `actions:write` → startup_failure avant même le démarrage des jobs. Fix : bloc `permissions` ajouté au job caller.
- **PR Validation lint failure (Renovate PR #76)** : `eslint-plugin-react-hooks` 7.0.1 → 7.1.1 active les règles React Compiler dans `recommended`. Deux violations dans `useTasks.js` :
  - `fetchTasks()` appelée avant sa déclaration → fonction déplacée avant le `useEffect`
  - `setTasks([])` setState synchrone dans un effet → branche `else` supprimée, retour dérive `session?.user ? tasks : []`

## Test plan

- [ ] Docker Validation doit passer sur le prochain push vers main (plus de startup_failure)
- [ ] La PR Renovate #76 doit passer le lint après merge de ce fix dans main
- [ ] Vérifier que l'affichage des tâches fonctionne normalement (connexion → tâches visibles, déconnexion → liste vide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)