### PR TITLE
fix(security): suppress 18 new false-positive code scanning alerts

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -5,3 +5,6 @@ server/tests/
 client/src/**/*.test.*
 server/drizzle/
 coverage/
+# Better Auth email templates — {{ .ConfirmationURL }} is server-generated, not user input
+server/db/reset_password.html
+server/db/confirm_signup.html

--- a/.trivyignore
+++ b/.trivyignore
@@ -126,3 +126,34 @@ CVE-2026-31802
 CVE-2026-26996
 CVE-2026-27903
 CVE-2026-27904
+
+# ============================================================
+# New Go stdlib CVEs in esbuild binaries (drizzle-kit + @esbuild-kit/core-utils)
+# Same rationale as above: esbuild is a CLI build tool, never a network server.
+# ============================================================
+# golang.org/x/net/proxy: HTTP Proxy bypass via IPv6 Zone IDs
+CVE-2025-22870
+# crypto/x509 + crypto/tls: DoS via certificate chain building
+CVE-2026-32280
+# crypto/x509: DoS via inefficient certificate chain validation
+CVE-2026-32281
+# internal/syscall/unix: Root.Chmod can follow symlinks out of root
+CVE-2026-32282
+# crypto/tls: DoS via multiple key update messages
+CVE-2026-32283
+# archive/tar: DoS via maliciously-crafted archive
+CVE-2026-32288
+# html/template: XSS via improper JS template literal context tracking
+CVE-2026-32289
+
+# ============================================================
+# npm bundled picomatch and brace-expansion (usr/local/lib/node_modules/npm/)
+# ============================================================
+# npm's own internal packages — production container does not run npm install
+# from untrusted sources at runtime.
+# picomatch: ReDoS via crafted extglob patterns
+CVE-2026-33671
+# picomatch: data integrity via method injection with POSIX bracket expressions
+CVE-2026-33672
+# brace-expansion: DoS via zero step value in brace pattern
+CVE-2026-33750


### PR DESCRIPTION
## Summary

- **`.trivyignore`** — 10 new CVEs added: 7 Go stdlib CVEs in the esbuild binary embedded in `drizzle-kit` / `@esbuild-kit/core-utils` (CVE-2025-22870, CVE-2026-32280/81/82/83/88/89) and 3 npm-bundled CVEs (picomatch ReDoS/integrity, brace-expansion DoS). Same rationale as existing entries: esbuild is a CLI build tool, never a network server in production.
- **`.semgrepignore`** — Add Better Auth HTML email templates (`reset_password.html`, `confirm_signup.html`) to silence `var-in-href` findings on `{{ .ConfirmationURL }}`, which is a server-generated URL, not user input.

## Test plan

- [ ] Security & Performance workflow runs → Semgrep finds 0 alerts on the two HTML templates
- [ ] Existing tests and lint pass (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)